### PR TITLE
Added cursor type to nav buttons

### DIFF
--- a/origin/scss/components/navs/_navs.scss
+++ b/origin/scss/components/navs/_navs.scss
@@ -3,9 +3,12 @@
 	padding: 0;
 
 	li {
+		cursor: pointer;
+		
 		a {
 			@extend .block;
 		}
+		
 	}
 }
 	.nav-tabs {


### PR DESCRIPTION
Cursor wasn't showing correctly on li elements in .nav class.
cursor now set to type "pointer".